### PR TITLE
新增 @Ipc 装饰器，移除默认错误处理

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug TEST [nest-electron]",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/nest-electron/test/mock",
+      "runtimeExecutable": "${workspaceFolder}/packages/nest-electron/node_modules/.bin/electron",
+      "program": "${workspaceFolder}/packages/nest-electron/test/mock/dist/main.js",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+    }
+  ]
+}

--- a/packages/nest-electron/package.json
+++ b/packages/nest-electron/package.json
@@ -35,6 +35,7 @@
     "@nestjs/common": "9.3.8",
     "@nestjs/core": "9.3.8",
     "electron": "23.0.0",
-    "reflect-metadata": "0.1.13"
+    "reflect-metadata": "0.1.13",
+    "rxjs": "^7.8.0"
   }
 }

--- a/packages/nest-electron/package.json
+++ b/packages/nest-electron/package.json
@@ -27,8 +27,8 @@
     "test": "npm run build && vitest run"
   },
   "peerDependencies": {
-    "@nestjs/common": ">=6.0.0",
-    "@nestjs/microservices": ">=6.0.0",
+    "@nestjs/common": "^9.3.5",
+    "@nestjs/microservices": "^9.3.5",
     "electron": ">=16.0.0"
   },
   "devDependencies": {

--- a/packages/nest-electron/src/transport/filter.ts
+++ b/packages/nest-electron/src/transport/filter.ts
@@ -1,9 +1,0 @@
-import type { ExceptionFilter } from '@nestjs/common'
-import { Catch } from '@nestjs/common'
-
-@Catch()
-export class IpcExceptionsFilter implements ExceptionFilter {
-  catch(exception: any) {
-    throw exception
-  }
-}

--- a/packages/nest-electron/src/transport/index.ts
+++ b/packages/nest-electron/src/transport/index.ts
@@ -1,2 +1,1 @@
 export * from './dispatcher'
-export * from './filter'

--- a/packages/nest-electron/test/mock/index.html
+++ b/packages/nest-electron/test/mock/index.html
@@ -16,7 +16,9 @@
       printLog,
       sendMultiParams,
       throwError,
-      exit
+      exit,
+      ipcChat,
+      throwIpcError,
     } = window.electron
 
     const test = async () => {
@@ -29,6 +31,15 @@
       const msgFromBackend = await chat('This is a message to backend')
 
       await printLog(msgFromBackend)
+
+      try {
+        await throwIpcError()
+      } catch (error) {
+        // await printLog('aaaaa')
+        await printLog(error.message)
+      }
+
+      await printLog(await ipcChat('This is a message to backend using @Ipc'))
 
       await sendMultiParams('this is a param1', 'this is a param2')
 

--- a/packages/nest-electron/test/mock/index.html
+++ b/packages/nest-electron/test/mock/index.html
@@ -35,7 +35,6 @@
       try {
         await throwIpcError()
       } catch (error) {
-        // await printLog('aaaaa')
         await printLog(error.message)
       }
 

--- a/packages/nest-electron/test/mock/src/app.controller.ts
+++ b/packages/nest-electron/test/mock/src/app.controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from '@nestjs/common'
 import { BrowserWindow, app } from 'electron'
-import { IpcHandle, IpcOn, Window } from '../../../dist'
+import { Ipc, IpcHandle, IpcOn, Window } from '../../../dist'
 
 @Controller()
 export class AppController {
@@ -13,6 +13,17 @@ export class AppController {
 
     if (this.anotherWin instanceof BrowserWindow)
       console.log('Inject another BrowserWindow successfully')
+  }
+
+  @Ipc('ipc-chat')
+  ipcChat(msg: string) {
+    console.log(`Get message from frontend via @Ipc: ${msg}`)
+    return 'This is a message to frontend using @Ipc'
+  }
+
+  @Ipc('ipc-error')
+  throwIpcError() {
+    throw new Error('This is an error throw by @ipc')
   }
 
   @IpcHandle('chat')

--- a/packages/nest-electron/test/mock/src/app.module.ts
+++ b/packages/nest-electron/test/mock/src/app.module.ts
@@ -1,13 +1,16 @@
 import { join } from 'path'
 import { Module } from '@nestjs/common'
+import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core'
 import { BrowserWindow } from 'electron'
 import { ElectronModule } from '../../../dist'
 import { AppController } from './app.controller'
+import { ResponseInterceptor } from './interceptors/response.interceptor'
+import { AllExecptionFilter } from './filters/all-exception.filter'
 
 @Module({
   imports: [
     ElectronModule.registerAsync({
-      // name: 'main', // default window names "main"
+    // name: 'main', // default window names "main"
       useFactory: async () => {
         const win = new BrowserWindow({
           webPreferences: {
@@ -46,5 +49,15 @@ import { AppController } from './app.controller'
     }),
   ],
   controllers: [AppController],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ResponseInterceptor,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: AllExecptionFilter,
+    },
+  ],
 })
 export class AppModule { }

--- a/packages/nest-electron/test/mock/src/filters/all-exception.filter.ts
+++ b/packages/nest-electron/test/mock/src/filters/all-exception.filter.ts
@@ -1,0 +1,15 @@
+import { Catch } from '@nestjs/common'
+import { of } from 'rxjs'
+import type { Observable } from 'rxjs'
+import type { ExceptionFilter } from '@nestjs/common'
+
+@Catch() // catch all exception
+export class AllExecptionFilter implements ExceptionFilter {
+  catch(exception: any): Observable<any> {
+    return of({
+      code: 1,
+      message: exception.message,
+      ...exception,
+    })
+  }
+}

--- a/packages/nest-electron/test/mock/src/filters/all-exception.filter.ts
+++ b/packages/nest-electron/test/mock/src/filters/all-exception.filter.ts
@@ -7,9 +7,9 @@ import type { ExceptionFilter } from '@nestjs/common'
 export class AllExecptionFilter implements ExceptionFilter {
   catch(exception: any): Observable<any> {
     return of({
+      ...exception,
       code: 1,
       message: exception.message,
-      ...exception,
     })
   }
 }

--- a/packages/nest-electron/test/mock/src/interceptors/response.interceptor.ts
+++ b/packages/nest-electron/test/mock/src/interceptors/response.interceptor.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common'
+import { map } from 'rxjs/operators'
+import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common'
+import type { Observable } from 'rxjs'
+
+@Injectable()
+export class ResponseInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(
+      map((data) => {
+        return {
+          code: 0,
+          message: 'ok',
+          data,
+        }
+      }),
+    )
+  }
+}

--- a/packages/nest-electron/test/mock/src/preload.ts
+++ b/packages/nest-electron/test/mock/src/preload.ts
@@ -1,12 +1,23 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
-contextBridge.exposeInMainWorld(
-  'electron',
-  {
-    chat: (msg: string): Promise<string> => ipcRenderer.invoke('chat', msg),
-    throwError: (): Promise<void> => ipcRenderer.invoke('error'),
-    printLog: (log: string): void => ipcRenderer.send('print-log', log),
-    sendMultiParams: (param1: string, param2: string): void => ipcRenderer.send('multi-params', param1, param2),
-    exit: (): void => ipcRenderer.send('exit'),
-  },
-)
+async function invoke<TResult = any, TArg = any>(channel: string, ...args: TArg[]): Promise<TResult> {
+  const res = await ipcRenderer.invoke(channel, ...args)
+
+  if (res.code)
+    throw res
+
+  return res.data
+}
+
+const electronIpc = {
+  chat: (msg: string) => invoke<string>('chat', msg),
+  ipcChat: (msg: string) => invoke<string>('ipc-chat', msg),
+  throwError: () => invoke('error'),
+  throwIpcError: () => invoke('ipc-error'),
+  printLog: (log: string): void => ipcRenderer.send('print-log', log),
+  sendMultiParams: (param1: string, param2: string): void => ipcRenderer.send('multi-params', param1, param2),
+  exit: (): void => ipcRenderer.send('exit'),
+}
+
+contextBridge.exposeInMainWorld('electron', electronIpc)
+export type ElectronIPC = typeof electronIpc

--- a/packages/nest-electron/test/mock/tsup.config.ts
+++ b/packages/nest-electron/test/mock/tsup.config.ts
@@ -3,8 +3,7 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   name: 'nest-electron-test',
   target: 'node14',
-  clean: true,
+  clean: false,
   splitting: true,
-  entry: ['src/main.ts', 'src/preload.ts'],
   external: ['electron', '@nestjs', '../../../dist'],
 })

--- a/packages/nest-electron/test/mock/types/global.d.ts
+++ b/packages/nest-electron/test/mock/types/global.d.ts
@@ -1,0 +1,8 @@
+import type { ElectronIPC } from '../src/preload';
+declare global {
+  interface Window {
+    electron: ElectronIPC;
+  }
+}
+
+export {};

--- a/packages/nest-electron/tsconfig.json
+++ b/packages/nest-electron/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "declaration": true,
     "noImplicitAny": false,
-    "removeComments": true,
+    "removeComments": false,
     "noLib": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,12 +73,12 @@ importers:
     specifiers:
       '@nestjs/common': 9.3.8
       '@nestjs/core': 9.3.8
-      '@nestjs/microservices': '>=6.0.0'
+      '@nestjs/microservices': ^9.3.5
       electron: 23.0.0
       reflect-metadata: 0.1.13
       rxjs: ^7.8.0
     dependencies:
-      '@nestjs/microservices': 9.0.11_rfkwsi4anokjnfq4xl4onkvzwa
+      '@nestjs/microservices': 9.3.8_rfkwsi4anokjnfq4xl4onkvzwa
     devDependencies:
       '@nestjs/common': 9.3.8_mnr6j2del53muneqly5h4y27ai
       '@nestjs/core': 9.3.8_6sysrfnceog466mrogtvxnbmxe
@@ -838,38 +838,6 @@ packages:
       tslib: 2.5.0
       uid: 2.0.1
 
-  /@nestjs/core/9.3.8_67fuby44ix4iqquztl7cj7hhoy:
-    resolution: {integrity: sha512-LtKMF7qzlSN+B4lItxHc/r9IJTSgURZAT5LqMtZynmYDpIkkiG7UrKKx/jAolUF41SGkKXzC6Lh+yralZ97i5A==}
-    requiresBuild: true
-    peerDependencies:
-      '@nestjs/common': ^9.0.0
-      '@nestjs/microservices': ^9.0.0
-      '@nestjs/platform-express': ^9.0.0
-      '@nestjs/websockets': ^9.0.0
-      reflect-metadata: ^0.1.12
-      rxjs: ^7.1.0
-    peerDependenciesMeta:
-      '@nestjs/microservices':
-        optional: true
-      '@nestjs/platform-express':
-        optional: true
-      '@nestjs/websockets':
-        optional: true
-    dependencies:
-      '@nestjs/common': 9.3.8_mnr6j2del53muneqly5h4y27ai
-      '@nestjs/microservices': 9.0.11_rfkwsi4anokjnfq4xl4onkvzwa
-      '@nuxtjs/opencollective': 0.3.2
-      fast-safe-stringify: 2.1.1
-      iterare: 1.2.1
-      path-to-regexp: 3.2.0
-      reflect-metadata: 0.1.13
-      rxjs: 7.8.0
-      tslib: 2.5.0
-      uid: 2.0.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@nestjs/core/9.3.8_6sysrfnceog466mrogtvxnbmxe:
     resolution: {integrity: sha512-LtKMF7qzlSN+B4lItxHc/r9IJTSgURZAT5LqMtZynmYDpIkkiG7UrKKx/jAolUF41SGkKXzC6Lh+yralZ97i5A==}
     requiresBuild: true
@@ -931,51 +899,6 @@ packages:
       uid: 2.0.1
     transitivePeerDependencies:
       - encoding
-    dev: true
-
-  /@nestjs/microservices/9.0.11_rfkwsi4anokjnfq4xl4onkvzwa:
-    resolution: {integrity: sha512-SalP+y96HAsrNnPkt+RQAYlPSzofs/D90Y0ZS9oveBiCQhezKSnkBZ7Qpv3uLFbs6TsL/VHG9nVoQC6aiZA0ww==}
-    peerDependencies:
-      '@grpc/grpc-js': '*'
-      '@nestjs/common': ^9.0.0
-      '@nestjs/core': ^9.0.0
-      '@nestjs/websockets': ^9.0.0
-      amqp-connection-manager: '*'
-      amqplib: '*'
-      cache-manager: '*'
-      ioredis: '*'
-      kafkajs: '*'
-      mqtt: '*'
-      nats: '*'
-      reflect-metadata: ^0.1.12
-      rxjs: ^7.1.0
-    peerDependenciesMeta:
-      '@grpc/grpc-js':
-        optional: true
-      '@nestjs/websockets':
-        optional: true
-      amqp-connection-manager:
-        optional: true
-      amqplib:
-        optional: true
-      cache-manager:
-        optional: true
-      ioredis:
-        optional: true
-      kafkajs:
-        optional: true
-      mqtt:
-        optional: true
-      nats:
-        optional: true
-    dependencies:
-      '@nestjs/common': 9.3.8_mnr6j2del53muneqly5h4y27ai
-      '@nestjs/core': 9.3.8_67fuby44ix4iqquztl7cj7hhoy
-      iterare: 1.2.1
-      reflect-metadata: 0.1.13
-      rxjs: 7.8.0
-      tslib: 2.4.0
-    dev: false
 
   /@nestjs/microservices/9.3.8_rfkwsi4anokjnfq4xl4onkvzwa:
     resolution: {integrity: sha512-A4+LJlhDwMig/y/L8jI5/EQEZp0v3fpCMS4Ll1w4BcxuuyUSwLBF4AZdta7X4adb93Yo5qy7eNCVF3tyWl715Q==}
@@ -1019,7 +942,6 @@ packages:
       reflect-metadata: 0.1.13
       rxjs: 7.8.0
       tslib: 2.5.0
-    dev: true
 
   /@nestjs/testing/9.3.8_znlpu2ktzydjx7rl4llynpumdm:
     resolution: {integrity: sha512-QyGOfrEOWbT8mi7ruYnh/taKuHDv4caAyf4WZ1YKkGn4tCeTKKNXSvV/y+NoO5o9Li/sLiq9B8EmleB1fxGajw==}
@@ -1146,6 +1068,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
@@ -1165,6 +1088,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
@@ -1184,6 +1108,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
@@ -1203,6 +1128,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: false
     optional: true
@@ -5853,10 +5779,6 @@ packages:
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
-
-  /tslib/2.4.0:
-    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,13 +76,15 @@ importers:
       '@nestjs/microservices': '>=6.0.0'
       electron: 23.0.0
       reflect-metadata: 0.1.13
+      rxjs: ^7.8.0
     dependencies:
       '@nestjs/microservices': 9.0.11_rfkwsi4anokjnfq4xl4onkvzwa
     devDependencies:
       '@nestjs/common': 9.3.8_mnr6j2del53muneqly5h4y27ai
-      '@nestjs/core': 9.3.8_67fuby44ix4iqquztl7cj7hhoy
+      '@nestjs/core': 9.3.8_6sysrfnceog466mrogtvxnbmxe
       electron: 23.0.0
       reflect-metadata: 0.1.13
+      rxjs: 7.8.0
 
   packages/nest-electron-ipc-transport:
     specifiers:
@@ -866,6 +868,7 @@ packages:
       uid: 2.0.1
     transitivePeerDependencies:
       - encoding
+    dev: false
 
   /@nestjs/core/9.3.8_6sysrfnceog466mrogtvxnbmxe:
     resolution: {integrity: sha512-LtKMF7qzlSN+B4lItxHc/r9IJTSgURZAT5LqMtZynmYDpIkkiG7UrKKx/jAolUF41SGkKXzC6Lh+yralZ97i5A==}
@@ -972,6 +975,7 @@ packages:
       reflect-metadata: 0.1.13
       rxjs: 7.8.0
       tslib: 2.4.0
+    dev: false
 
   /@nestjs/microservices/9.3.8_rfkwsi4anokjnfq4xl4onkvzwa:
     resolution: {integrity: sha512-A4+LJlhDwMig/y/L8jI5/EQEZp0v3fpCMS4Ll1w4BcxuuyUSwLBF4AZdta7X4adb93Yo5qy7eNCVF3tyWl715Q==}
@@ -1151,6 +1155,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -1169,6 +1174,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -1187,6 +1193,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -1205,6 +1212,7 @@ packages:
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -5848,6 +5856,7 @@ packages:
 
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+    dev: false
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}


### PR DESCRIPTION
修改明细：

1. 新增 @Ipc 装饰器，原有装饰器带有 `MultiParams` 会造成 `@Payload` 无效，且自定义其他装饰器、Filter 等，拿到的 `args` 参数会有多层array包裹。 常规 `nestjs` HTTP 的请求一般也是 `POST` 一个 `JSON` 的大对象，然后通过DTO、解构或者参数注解去获取各个值。
2. 移除 useFilters, 将错误处理交给用户。（用户必须自行处理，或者抛出  [RpcException](https://docs.nestjs.com/microservices/exception-filters) ， 否则由于 nestjs 的内部规则，会抛出 `Internal server error` )
3. 增加 test case, 并有执行结果/错误转换的示例。