### PR TITLE
fix(plugin-vite): Ensure rendererUrl is set before calling dev(userCo…

### DIFF
--- a/packages/plugin-vite/src/index.ts
+++ b/packages/plugin-vite/src/index.ts
@@ -46,14 +46,19 @@ export function VitePluginDoubleshot(userConfig: Partial<VitePluginDoubleshotCon
       },
       configureServer(server) {
         const printUrls = server.printUrls.bind(server)
+        let rendererUrlSet = false
         // override printUrls to get rendererUrl
         server.printUrls = () => {
           printUrls()
           if (!userConfig.rendererUrl)
             userConfig.rendererUrl = server.resolvedUrls!.local[0]
+          rendererUrlSet = true
         }
 
         server?.httpServer?.on('listening', async () => {
+          while (!rendererUrlSet) {
+            await new Promise(resolve => setTimeout(resolve, 10));
+          }
           await dev(userConfig)
         })
       },


### PR DESCRIPTION
**起因**
详见：https://github.com/ArcherGu/fast-vite-electron/issues/1074 ，在其他电脑（macos）中也复现了该问题。重复`启动-停止-启动`的过程中有可能会出现该问题。同时我也观察到在日志中 `DSB xx` 的日志优先 `printUrls()` 的内容输出时就会报错，也侧面证明了存在竞态条件的问题。

**描述**
解决了 Vite Plugin Doubleshot 插件中一个潜在的竞态条件问题。在 Vite 开发服务器启动时，`rendererUrl` 可能在调用 `dev(userConfig)` 之前没有正确设置，导致 `rendererUrl` 的值不正确，从而在开发过程中引发问题。

**变更内容**
	•	添加标志：引入了一个 rendererUrlSet 标志，用于跟踪 rendererUrl 是否已被设置。
	•	修改 server.printUrls：调整了该方法以设置 rendererUrl 并更新 rendererUrlSet 标志。
	•	更新 listening 事件处理器：确保在调用 dev(userConfig) 之前检查 rendererUrlSet 标志，并确保 rendererUrl 已被设置。

